### PR TITLE
[DWP-1749] fix: azkaban sync rollout deployment bug and migrate to artifact registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,19 +88,19 @@ Things that you need to change:
 ```
 ./gradlew clean build installDist
 
-docker build -t  asia-southeast1-docker.pkg.dev/[project-id]/data-engineering/azkaban-sync:[image-tag] -f Dockerfile-sync .
-docker build -t  asia-southeast1-docker.pkg.dev/[project-id]/data-engineering/azkaban-exec:[image-tag] -f Dockerfile-exec .
-docker build -t  asia-southeast1-docker.pkg.dev/[project-id]/data-engineering/azkaban-web:[image-tag] -f Dockerfile-web .
+DOCKER_HOST=172.16.0.28:2375 docker build -t  asia-southeast1-docker.pkg.dev/[project-id]/data-engineering/azkaban-sync:[image-tag] -f Dockerfile-sync .
+DOCKER_HOST=172.16.0.28:2375 docker build -t  asia-southeast1-docker.pkg.dev/[project-id]/data-engineering/azkaban-exec:[image-tag] -f Dockerfile-exec .
+DOCKER_HOST=172.16.0.28:2375 docker build -t  asia-southeast1-docker.pkg.dev/[project-id]/data-engineering/azkaban-web:[image-tag] -f Dockerfile-web .
 
 # add '--platform linux/amd64' in `docker build` command if you're building in Apple Silicon ([src](https://dev.to/lakhansamani/create-docker-image-on-apple-silicon-m1-mac-2f75))
 # e.g.:
-# docker build --platform linux/amd64 -t  asia-southeast1-docker.pkg.dev/[project-id]/data-engineering/azkaban-sync:[image-tag] -f Dockerfile-sync .
-# docker build --platform linux/amd64 -t  asia-southeast1-docker.pkg.dev/[project-id]/data-engineering/azkaban-exec:[image-tag] -f Dockerfile-exec .
-# docker build --platform linux/amd64 -t  asia-southeast1-docker.pkg.dev/[project-id]/data-engineering/azkaban-web:[image-tag] -f Dockerfile-web .
+# DOCKER_HOST=172.16.0.28:2375 docker build --platform linux/amd64 -t  asia-southeast1-docker.pkg.dev/[project-id]/data-engineering/azkaban-sync:[image-tag] -f Dockerfile-sync .
+# DOCKER_HOST=172.16.0.28:2375 docker build --platform linux/amd64 -t  asia-southeast1-docker.pkg.dev/[project-id]/data-engineering/azkaban-exec:[image-tag] -f Dockerfile-exec .
+# DOCKER_HOST=172.16.0.28:2375 docker build --platform linux/amd64 -t  asia-southeast1-docker.pkg.dev/[project-id]/data-engineering/azkaban-web:[image-tag] -f Dockerfile-web .
 
-docker push  asia-southeast1-docker.pkg.dev/[project-id]/data-engineering/azkaban-sync:[image-tag]
-docker push  asia-southeast1-docker.pkg.dev/[project-id]/data-engineering/azkaban-exec:[image-tag]
-docker push  asia-southeast1-docker.pkg.dev/[project-id]/data-engineering/azkaban-web:[image-tag]
+DOCKER_HOST=172.16.0.28:2375 docker push  asia-southeast1-docker.pkg.dev/[project-id]/data-engineering/azkaban-sync:[image-tag]
+DOCKER_HOST=172.16.0.28:2375 docker push  asia-southeast1-docker.pkg.dev/[project-id]/data-engineering/azkaban-exec:[image-tag]
+DOCKER_HOST=172.16.0.28:2375 docker push  asia-southeast1-docker.pkg.dev/[project-id]/data-engineering/azkaban-web:[image-tag]
 
 kubectl -n [gke-namespace] apply -f yaml/
 ```

--- a/README.md
+++ b/README.md
@@ -88,19 +88,19 @@ Things that you need to change:
 ```
 ./gradlew clean build installDist
 
-docker build -t gcr.io/[project-id]/azkaban-sync:[image-tag] -f Dockerfile-sync .
-docker build -t gcr.io/[project-id]/azkaban-exec:[image-tag] -f Dockerfile-exec .
-docker build -t gcr.io/[project-id]/azkaban-web:[image-tag] -f Dockerfile-web .
+docker build -t  asia-southeast1-docker.pkg.dev/[project-id]/data-engineering/azkaban-sync:[image-tag] -f Dockerfile-sync .
+docker build -t  asia-southeast1-docker.pkg.dev/[project-id]/data-engineering/azkaban-exec:[image-tag] -f Dockerfile-exec .
+docker build -t  asia-southeast1-docker.pkg.dev/[project-id]/data-engineering/azkaban-web:[image-tag] -f Dockerfile-web .
 
 # add '--platform linux/amd64' in `docker build` command if you're building in Apple Silicon ([src](https://dev.to/lakhansamani/create-docker-image-on-apple-silicon-m1-mac-2f75))
 # e.g.:
-# docker build --platform linux/amd64 -t gcr.io/[project-id]/azkaban-sync:[image-tag] -f Dockerfile-sync .
-# docker build --platform linux/amd64 -t gcr.io/[project-id]/azkaban-exec:[image-tag] -f Dockerfile-exec .
-# docker build --platform linux/amd64 -t gcr.io/[project-id]/azkaban-web:[image-tag] -f Dockerfile-web .
+# docker build --platform linux/amd64 -t  asia-southeast1-docker.pkg.dev/[project-id]/data-engineering/azkaban-sync:[image-tag] -f Dockerfile-sync .
+# docker build --platform linux/amd64 -t  asia-southeast1-docker.pkg.dev/[project-id]/data-engineering/azkaban-exec:[image-tag] -f Dockerfile-exec .
+# docker build --platform linux/amd64 -t  asia-southeast1-docker.pkg.dev/[project-id]/data-engineering/azkaban-web:[image-tag] -f Dockerfile-web .
 
-docker push gcr.io/[project-id]/azkaban-sync:[image-tag]
-docker push gcr.io/[project-id]/azkaban-exec:[image-tag]
-docker push gcr.io/[project-id]/azkaban-web:[image-tag]
+docker push  asia-southeast1-docker.pkg.dev/[project-id]/data-engineering/azkaban-sync:[image-tag]
+docker push  asia-southeast1-docker.pkg.dev/[project-id]/data-engineering/azkaban-exec:[image-tag]
+docker push  asia-southeast1-docker.pkg.dev/[project-id]/data-engineering/azkaban-web:[image-tag]
 
 kubectl -n [gke-namespace] apply -f yaml/
 ```

--- a/scripts/sync_exec.py
+++ b/scripts/sync_exec.py
@@ -15,11 +15,11 @@ def check_exec_pods_stability():
     cmd = 'kubectl -n [gke-namespace] get po -o wide|grep exec|grep 2/2|grep Running|wc -l'
     num_stable_pods = int(getoutput(cmd))
 
-    cmd = "kubectl -n [gke-namespace] get po -o wide|grep exec|grep -v Evicted|grep -Ev '0/2.*Terminating'|wc -l"
-    num_evicted_pods = int(getoutput(cmd))
+    cmd = "kubectl -n [gke-namespace] get deployment exec -o jsonpath=\"{@.spec.replica}\""
+    num_all_pods = int(getoutput(cmd))
 
     # num_stable_pods >= num_evicted_pods
-    stable = num_stable_pods >= num_evicted_pods
+    stable = num_stable_pods >= num_all_pods
     return stable
 
 

--- a/scripts/sync_exec.py
+++ b/scripts/sync_exec.py
@@ -16,9 +16,10 @@ def check_exec_pods_stability():
     num_stable_pods = int(getoutput(cmd))
 
     cmd = "kubectl -n [gke-namespace] get po -o wide|grep exec|grep -v Evicted|grep -Ev '0/2.*Terminating'|wc -l"
-    num_all_pods = int(getoutput(cmd))
+    num_evicted_pods = int(getoutput(cmd))
 
-    stable = num_stable_pods == num_all_pods
+    # num_stable_pods >= num_evicted_pods
+    stable = num_stable_pods >= num_evicted_pods
     return stable
 
 

--- a/scripts/sync_exec.py
+++ b/scripts/sync_exec.py
@@ -15,7 +15,7 @@ def check_exec_pods_stability():
     cmd = 'kubectl -n [gke-namespace] get po -o wide|grep exec|grep 2/2|grep Running|wc -l'
     num_stable_pods = int(getoutput(cmd))
 
-    cmd = "kubectl -n [gke-namespace] get deployment exec -o jsonpath=\"{@.spec.replica}\""
+    cmd = "kubectl -n [gke-namespace] get deployment exec -o jsonpath=\"{@.spec.replicas}\""
     num_all_pods = int(getoutput(cmd))
 
     # num_stable_pods >= num_evicted_pods

--- a/yaml/exec.yaml
+++ b/yaml/exec.yaml
@@ -19,8 +19,8 @@ spec:
         - containerPort: 12321
         resources:
           requests:
-            memory: "20G"
-            cpu: "6500m"
+            memory: "14G"
+            cpu: "1800m"
         livenessProbe:
           failureThreshold: 5
           exec:

--- a/yaml/exec.yaml
+++ b/yaml/exec.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: exec
-        image: gcr.io/[project-id]/azkaban-exec:[image-tag]
+        image:  asia-southeast1-docker.pkg.dev/[project-id]/data-engineering/azkaban-exec:[image-tag]
         ports:
         - containerPort: 12321
         resources:

--- a/yaml/web.yaml
+++ b/yaml/web.yaml
@@ -21,7 +21,7 @@ spec:
         resources:
           requests:
             memory: "18G"
-            cpu: "6000m"
+            cpu: "600m"
         livenessProbe:
           failureThreshold: 5
           exec:

--- a/yaml/web.yaml
+++ b/yaml/web.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: web
-        image: gcr.io/[project-id]/azkaban-web:[image-tag]
+        image:  asia-southeast1-docker.pkg.dev/[project-id]/data-engineering/azkaban-web:[image-tag]
         ports:
         - containerPort: 8081
         resources:
@@ -52,7 +52,7 @@ spec:
             mountPath: /secrets/azkaban-users-xml
             readOnly: true
       - name: sync
-        image: gcr.io/[project-id]/azkaban-sync:[image-tag]
+        image:  asia-southeast1-docker.pkg.dev/[project-id]/data-engineering/azkaban-sync:[image-tag]
         command: ["/scripts/sync_exec.py", "[project-id]"]
         volumeMounts:
           - name: service-account-credential


### PR DESCRIPTION
## Why?

wrong bash command

example: the total is 14 when we have rollout deployment, we just want the desirable deployment right?
just change it into replicas on deployment

<img width="1054" alt="Screen Shot 2023-02-02 at 09 14 32" src="https://user-images.githubusercontent.com/9495683/216214492-e07756c1-d245-4f65-a510-0a5beba1d7e5.png">

## Fix
- fix the logic of infinite loop because of wrong command
- rebuild and push the image
- rollout restart
- try job at azkaban web

## Test
1. on staging run this command (4 replica)
```
kcgd -n data-eng-staging rollout restart -lapp=exec
```
2. open this link https://azk-stg.sirogu.com/manager?project=sql_etl__staging__briandi-dwp-lp-ctr&flow=etl-rg-data-dev.rg_dwp.fact_rg_landing_page_ctr_raw 

3. execute the flow

## Deploy

Image already uploaded to staging and prod artifact registry, if web redeployed/restarted, it will use new rule

<img width="1260" alt="Screen Shot 2023-02-02 at 09 19 49" src="https://user-images.githubusercontent.com/9495683/216215194-c48ef54b-8c7e-40a5-93f3-af290ca11521.png">
<img width="1182" alt="Screen Shot 2023-02-02 at 09 19 37" src="https://user-images.githubusercontent.com/9495683/216215207-75241ccc-bf65-4f80-8035-5c11a3fcf692.png">
